### PR TITLE
Add signcolumn hide option

### DIFF
--- a/denops/@ddu-uis/std.ts
+++ b/denops/@ddu-uis/std.ts
@@ -400,6 +400,7 @@ export class Ui extends BaseUi<Params> {
     await fn.setwinvar(denops, winid, "&foldenable", 0);
     await fn.setwinvar(denops, winid, "&number", 0);
     await fn.setwinvar(denops, winid, "&relativenumber", 0);
+    await fn.setwinvar(denops, winid, "&signcolumn", 'no');
     await fn.setwinvar(denops, winid, "&spell", 0);
     await fn.setwinvar(denops, winid, "&wrap", 0);
 

--- a/denops/@ddu-uis/std.ts
+++ b/denops/@ddu-uis/std.ts
@@ -400,7 +400,7 @@ export class Ui extends BaseUi<Params> {
     await fn.setwinvar(denops, winid, "&foldenable", 0);
     await fn.setwinvar(denops, winid, "&number", 0);
     await fn.setwinvar(denops, winid, "&relativenumber", 0);
-    await fn.setwinvar(denops, winid, "&signcolumn", 'no');
+    await fn.setwinvar(denops, winid, "&signcolumn", "no");
     await fn.setwinvar(denops, winid, "&spell", 0);
     await fn.setwinvar(denops, winid, "&wrap", 0);
 


### PR DESCRIPTION
Added a setting to not show `signcolumn` in` ddu-ui-std`, since it is also shown in `ddu-ui-std` if it is set to show` signcolumn`.